### PR TITLE
Add container jobs and convert action to 'composite'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,39 @@
-name: Test Github Action
-on: [push, pull_request]
+name: Test
+
+on:
+  push:
+  pull_request:
+
 jobs:
-  test:
+
+  action:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Git repository
-        uses: actions/checkout@v2
-      - name: Run VUnit tests
-        uses: ./
-        with:
-          run_file: test/run.py
+
+    - uses: actions/checkout@v2
+
+    - name: Run VUnit tests
+      uses: ./
+      with:
+        run_file: test/run.py
+
+
+  container-job:
+    runs-on: ubuntu-latest
+    container: ghdl/vunit:mcode-master
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - run: test/run.py
+
+
+  container-step:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - uses: docker://ghdl/vunit:mcode-master
+      with:
+        args: test/run.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Run VUnit tests
       uses: ./
       with:
-        run_file: test/run.py
+        cmd: test/run.py
 
 
   container-job:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM ghdl/vunit:llvm
-
-# Copies your code file from your action repository to the filesystem path `/` of the container
-COPY entrypoint.sh /root/entrypoint.sh
-
-# Code file to execute when the docker container starts up (`entrypoint.sh`)
-ENTRYPOINT ["/root/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,20 +1,56 @@
-# VUnit GitHub action
+# VUnit and GitHub Actions
 
-This action tests your vhdl and verilog code with VUnit!
+This repository showcases several approaches for using VUnit in GitHub Actions. Subdir [test](test) contains the sources of an example HDL design, which is tested in the reference workflow: [.github/workflows/test.yml](.github/workflows/test.yml).
 
-## Inputs
+ATTENTION: Currently, execution of tests in OCI containers is supported only. Therefore, designs are tested on GNU/Linux only, because running Windows containers is not supported in GitHub Actions.
 
-### `run_file`
+NOTE: Among the simulators supported by VUnit, GHDL is the only one that can be freely used. Therefore, all these solutions use GHDL. However, the syntax is not constrained by that, so any other OCI image with other supported simulators can be used in private repositories and/or with self-hosted runners.
 
-**Optional** Path to the VUnit top level Python script. Default `run.py`.
+## Action
 
-## Example usage
+Using an Action is the most idiomatic and less verbose solution.
+
+```yml
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - uses: VUnit/vunit_action@master
+      with:
+        cmd: test/run.py
 ```
-uses: VUnit/vunit_action@master
-with:
-  run_file: path/to/run.py
+
+### Options
+
+- `cmd`: custom command or path to the VUnit top level Python script. Default: `run.py`.
+- `image`: OCI image name to run the tests in. Default: `ghdl/vunit:mcode`.
+
+## Container Job
+
+GitHub Actions workflows have built-in support for a job to be executed in a container. This alternative provides a finer grained definition of the steps to be executed in the container, before running the actual test script(s).
+
+```yml
+    runs-on: ubuntu-latest
+    container: ghdl/vunit:mcode
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - run: test/run.py
 ```
 
-## Test
-In `.github/workflows/test.yml` you find an example of use of this action
-applied to the `test/` directory.
+## Container Step
+
+Running a single step of a workflow inside a container is also supported in GitHub Actions. This solution is similar to the previous one, but allows executing other steps on the host either before or after running the test script(s).
+
+```yml
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - uses: docker://ghdl/vunit:mcode
+      with:
+        args: test/run.py
+```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
+<p align="center">
+  <a title="vunit.github.io"
+     href="http://vunit.github.io"
+  ><img src="https://img.shields.io/website.svg?label=vunit.github.io&longCache=true&style=flat-square&url=http%3A%2F%2Fvunit.github.io%2Findex.html"
+  /></a><!--
+  -->
+  <a title="Join the chat at https://gitter.im/VUnit/vunit"
+     href="https://gitter.im/VUnit/vunit"
+  ><img src="https://img.shields.io/gitter/room/VUnit/vunit.svg?longCache=true&style=flat-square&logo=gitter&logoColor=4db797&color=4db797"
+  /></a><!--
+  -->
+  <a title="@VUnitFramework"
+     href="https://www.twitter.com/VUnitFramework"
+  ><img src="https://img.shields.io/twitter/follow/VUnitFramework.svg?longCache=true&style=flat-square&color=1DA1F2&label=%40VUnitFramework&logo=twitter&logoColor=fff"
+  /></a><!--
+  -->
+  <a title="'Test' workflow Status"
+     href="https://github.com/VUnit/vunit_action/actions?query=workflow%3ATest"
+  ><img alt="'Test' workflow Status" src="https://img.shields.io/github/workflow/status/VUnit/vunit_action/Test?longCache=true&style=flat-square&label=Test"
+  /></a>
+</p>
+
+
 # VUnit and GitHub Actions
 
 This repository showcases several approaches for using VUnit in GitHub Actions. Subdir [test](test) contains the sources of an example HDL design, which is tested in the reference workflow: [.github/workflows/test.yml](.github/workflows/test.yml).

--- a/action.yml
+++ b/action.yml
@@ -1,15 +1,20 @@
-# action.yml
 name: 'VUnit Action'
-description: 'Automatically test your vhdl code with VUnit'
+description: 'Automatically test your VHDL code with VUnit'
+
 inputs:
-  run_file:
-    description: 'python VUnit run file'
+  cmd:
+    description: 'VUnit run script or command (Python)'
     default: 'run.py'
+  image:
+    description: 'Container image to run the script/command on'
+    default: ghdl/vunit:mcode
+
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
-  args:
-    - ${{ inputs.run_file }}
+  using: "composite"
+  steps:
+    - run: docker run --rm -v $(pwd):/src -w /src ${{ inputs.image }} ${{ inputs.cmd }}
+      shell: bash
+
 branding:
   icon: cpu
   color: blue

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh -l
-
-set -eu
-
-run_file="$1"
-
-python3 "$run_file"

--- a/test/run.py
+++ b/test/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from pathlib import Path
 from vunit import VUnit
 


### PR DESCRIPTION
This is a significant rewrite of this repo:

- Two additional jobs are added to the workflow, for showcasing how to run a job in a container, and how to run a single step of a job in a container.
- The Action is converted from a 'Docker action' to a 'Composite run steps Action' (https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/creating-a-composite-run-steps-action). That allows users to provide the image to be used, which is a new optional input.

The README is updated according to the enhancements.